### PR TITLE
Setup continuous delivery of Energy2026

### DIFF
--- a/.github/changelog-config.json
+++ b/.github/changelog-config.json
@@ -1,0 +1,29 @@
+{
+  "categories": [
+    {
+      "title": "## 🚀 Нові функції",
+      "labels": ["Feature Request", "Enhancement"]
+    },
+    {
+      "title": "## 🐛 Виправлення",
+      "labels": ["Bug"]
+    },
+    {
+      "title": "## ⚙️ CI/CD",
+      "labels": ["Continuous Integration", "Continuous Delivery", "Continuous Deployment"]
+    },
+    {
+      "title": "## ✅ Тестування",
+      "labels": ["Chore"]
+    },
+    {
+      "title": "## 🔨 Інші зміни",
+      "labels": ["Task"]
+    }
+  ],
+  "template": "${{CHANGELOG}}\n\n## 🔗 Корисні посилання\n- [Інструкція з інсталяції](README.md)\n- [GitHub Releases](https://github.com/${{OWNER}}/${{REPOSITORY}}/releases)",
+  "pr_template": "- ${{TITLE}} (#${{NUMBER}})",
+  "empty_template": "- Немає змін в цій категорії",
+  "sort": "ASC",
+  "base_branches": ["main"]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,3 +118,10 @@ jobs:
           name: build-logs
           path: target/ci-logs/**
           if-no-files-found: warn
+
+  # Stage 3: публікація пакету після успішної збірки.
+  publish:
+    name: Publish Package
+    needs: build
+    uses: ./.github/workflows/maven-publish.yml
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,6 @@ jobs:
   publish:
     name: Publish Package
     needs: build
-    if: github.event_name == 'push'
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,7 @@ jobs:
   publish:
     name: Publish Package
     needs: build
+    if: github.event_name == 'push'
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,5 +123,8 @@ jobs:
   publish:
     name: Publish Package
     needs: build
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/maven-publish.yml
     secrets: inherit

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -36,6 +36,6 @@ jobs:
 
       # Крок 3: Публікація артефактів в GitHub Packages
       - name: Publish to GitHub Packages
-        run: mvn --batch-mode deploy --file pom.xml -DskipTests
+        run: mvn --batch-mode deploy --file pom.xml -DskipTests -Dmaven.resolver.transport=wagon
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -36,6 +36,6 @@ jobs:
 
       # Крок 3: Публікація артефактів в GitHub Packages
       - name: Publish to GitHub Packages
-        run: mvn --batch-mode deploy --file pom.xml -DskipTests -Dmaven.resolver.transport=wagon
+        run: mvn --batch-mode deploy --file pom.xml -DskipTests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,0 +1,41 @@
+# Workflow для публікації пакетів Maven в GitHub Packages
+# GITHUB_ACTOR та GITHUB_TOKEN автоматично надаються GitHub Actions:
+# - GITHUB_ACTOR: ім'я користувача, який запустив workflow
+# - GITHUB_TOKEN: автоматично генерується для кожного запуску workflow
+#   і має необхідні права для публікації пакетів
+name: Maven Package
+
+# Запускається як частина CI pipeline або вручну
+on:
+  workflow_call:
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # Надання необхідних дозволів для публікації пакетів
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      # Крок 1: Отримання коду з репозиторію
+      - uses: actions/checkout@v4
+
+      # Крок 2: Налаштування JDK 17 з кешуванням залежностей Maven
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
+
+      # Крок 3: Публікація артефактів в GitHub Packages
+      - name: Publish to GitHub Packages
+        run: mvn --batch-mode deploy --file pom.xml -DskipTests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -36,6 +36,6 @@ jobs:
 
       # Крок 3: Публікація артефактів в GitHub Packages
       - name: Publish to GitHub Packages
-        run: mvn --batch-mode deploy --file pom.xml -DskipTests
+        run: mvn --batch-mode -X deploy --file pom.xml -DskipTests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -36,6 +36,6 @@ jobs:
 
       # Крок 3: Публікація артефактів в GitHub Packages
       - name: Publish to GitHub Packages
-        run: mvn --batch-mode -X deploy --file pom.xml -DskipTests
+        run: mvn --batch-mode deploy --file pom.xml -DskipTests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -1,0 +1,78 @@
+# Workflow для автоматичного створення релізів
+name: Maven Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: 'Release version (e.g., 0.2.0)'
+        required: true
+      developmentVersion:
+        description: 'Next development version (e.g., 0.3.0-SNAPSHOT)'
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
+
+      - name: Configure Git user
+        run: |
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Actions"
+
+      - name: Prepare Release
+        run: |
+          mvn release:prepare \
+            -DreleaseVersion=${{ github.event.inputs.releaseVersion }} \
+            -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }} \
+            -DtagNameFormat="@{project.version}" \
+            -B
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Perform Release
+        run: mvn release:perform
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Генерація changelog
+      - name: Generate Changelog
+        id: changelog
+        uses: mikepenz/release-changelog-builder-action@v4
+        with:
+          toTag: ${{ github.event.inputs.releaseVersion }}
+          configuration: ".github/changelog-config.json"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: ${{ github.event.inputs.releaseVersion }}
+          name: Energy2026 v${{ github.event.inputs.releaseVersion }}
+          body: ${{ steps.changelog.outputs.changelog }}
+          draft: true
+          prerelease: true
+          files: |
+            target/*.jar
+            README.md

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.energy</groupId>
-    <artifactId>Energy2026</artifactId>
+    <artifactId>еnergy2026</artifactId>
     <packaging>jar</packaging>
     <version>0.2.0-SNAPSHOT</version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.energy</groupId>
-    <artifactId>Energy2026</artifactId>
+    <groupId>org.energy</groupId> //Перейменовувати вже org.energy2026
+    <artifactId>Energy20262005</artifactId>
     <packaging>jar</packaging>
     <version>0.2.0-SNAPSHOT</version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.energy</groupId>
-    <artifactId>Energy20262005</artifactId>
+    <artifactId>Energy2026</artifactId>
     <packaging>jar</packaging>
     <version>0.2.0-SNAPSHOT</version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,13 @@
                 </executions>
             </plugin>
 
+            <!-- Fix for GitHub Packages 422 error -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.1.1</version>
+            </plugin>
+
             <!-- Maven Release Plugin -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,16 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <project.scm.id>github</project.scm.id>
     </properties>
+
+    <!-- SCM Information -->
+    <scm>
+        <connection>scm:git:https://github.com/Energy2026/Energy2026.git</connection>
+        <developerConnection>scm:git:https://github.com/Energy2026/Energy2026.git</developerConnection>
+        <url>https://github.com/Energy2026/Energy2026</url>
+        <tag>HEAD</tag>
+    </scm>
 
     <dependencies>
         <dependency>
@@ -45,6 +54,14 @@
             <version>5.12.0</version>
         </dependency>
     </dependencies>
+
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/Energy2026/Energy2026</url>
+        </repository>
+    </distributionManagement>
 
     <build>
         <plugins>
@@ -135,6 +152,19 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+
+            <!-- Maven Release Plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>3.0.1</version>
+                <configuration>
+                    <tagNameFormat>@{project.version}</tagNameFormat>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <releaseProfiles>release</releaseProfiles>
+                    <goals>deploy</goals>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.energy</groupId> //Перейменовувати вже org.energy2026
+    <groupId>org.energy</groupId>
     <artifactId>Energy20262005</artifactId>
     <packaging>jar</packaging>
     <version>0.2.0-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.energy</groupId>
-    <artifactId>еnergy2026</artifactId>
+    <artifactId>energy2026</artifactId>
     <packaging>jar</packaging>
     <version>0.2.0-SNAPSHOT</version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -158,9 +158,8 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>2.8.2</version>
             </plugin>
-
             <!-- Maven Release Plugin -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
### What does this PR do?
Setup continuous delivery and release automation for the Maven project.

- adds a GitHub Actions workflow to publish Maven artifacts to GitHub Packages
- adds a manual GitHub Actions release workflow that prepares/releases with Maven and creates a draft GitHub Release with a generated changelog
- adds changelog builder configuration for release notes categorization
- updates pom.xml with SCM metadata, GitHub Packages distribution management, and Maven Release Plugin configuration

### Related issue
#5 

### Description for the changelog

``` 
Set up Maven package publishing, automated releases, and changelog generation for the college schedule app.
```
