### PR TITLE
Add integration tests

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
   "features": {
     "ghcr.io/devcontainers/features/java:1": {
       "installMaven": "true"
-    }
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,10 +119,94 @@ jobs:
           path: target/ci-logs/**
           if-no-files-found: warn
 
-  # Stage 3: публікація пакету після успішної збірки.
+  integration-tests:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Run integration tests
+        shell: bash
+        run: |
+          mkdir -p target/ci-logs
+          set -o pipefail
+          mvn -B verify -DskipUTs=true -Dcheckstyle.skip=true | tee target/ci-logs/integration-tests.log
+
+      - name: Upload integration test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-reports
+          path: target/failsafe-reports/**
+          if-no-files-found: warn
+
+      - name: Upload integration coverage reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-coverage-reports
+          path: |
+            target/site/jacoco-it/**
+            target/jacoco-it.exec
+          if-no-files-found: warn
+
+      - name: Print integration coverage summary
+        if: always()
+        shell: bash
+        run: |
+          CSV_FILE="target/site/jacoco-it/jacoco.csv"
+          if [ ! -f "$CSV_FILE" ]; then
+            echo "Integration coverage report was not generated."
+            {
+              echo "## Integration Tests summary"
+              echo "Integration coverage report was not generated."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          {
+            echo "## Integration Tests summary"
+            echo ""
+            echo "Integration Test Coverage"
+          } >> "$GITHUB_STEP_SUMMARY"
+          while IFS=, read -r grp pkg cls i_miss i_cov b_miss b_cov l_miss l_cov c_miss c_cov m_miss m_cov; do
+            if [ "$cls" = "EnergyReading" ] || [ "$cls" = "EnergyReadingController" ]; then
+              total=$((l_cov + l_miss))
+              if [ "$total" -gt 0 ]; then
+                percent=$(awk -v c="$l_cov" -v t="$total" 'BEGIN {printf "%.2f", (c/t)*100}')
+              else
+                percent="0.00"
+              fi
+              {
+                echo ""
+                echo "org.energy.${cls}"
+                echo "Line coverage: ${percent}%"
+                echo "Covered lines: ${l_cov}"
+                echo "Missed lines: ${l_miss}"
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done < <(tail -n +2 "$CSV_FILE")
+
+      - name: Upload integration test logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-logs
+          path: target/ci-logs/**
+          if-no-files-found: warn
+
+  # Stage 4: публікація пакету після успішних інтеграційних тестів.
   publish:
     name: Publish Package
-    needs: build
+    needs: integration-tests
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
           path: target/ci-logs/**
           if-no-files-found: warn
 
-  build:
-    name: Build
+  unit-tests:
+    name: Unit Tests
     runs-on: ubuntu-latest
     needs: static-analysis
     steps:
@@ -52,20 +52,12 @@ jobs:
           java-version: "17"
           cache: maven
 
-      - name: Build project (includes unit tests)
+      - name: Run unit tests
         shell: bash
         run: |
           mkdir -p target/ci-logs
           set -o pipefail
-          mvn -B -Dcheckstyle.skip=true package | tee target/ci-logs/build.log
-
-      - name: Upload build artifact
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: build-artifacts
-          path: target/*.jar
-          if-no-files-found: warn
+          mvn -B package -Dcheckstyle.skip=true | tee target/ci-logs/unit-tests.log
 
       - name: Upload test reports
         if: always()
@@ -85,7 +77,7 @@ jobs:
             target/jacoco.exec
           if-no-files-found: warn
 
-      - name: Print coverage summary in build logs
+      - name: Print coverage summary
         if: always()
         shell: bash
         run: |
@@ -111,18 +103,18 @@ jobs:
             echo "Missed lines: ${MISSED}"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Upload build logs on failure
+      - name: Upload unit test logs on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: build-logs
+          name: unit-test-logs
           path: target/ci-logs/**
           if-no-files-found: warn
 
   integration-tests:
     name: Integration Tests
     runs-on: ubuntu-latest
-    needs: build
+    needs: unit-tests
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -203,10 +195,47 @@ jobs:
           path: target/ci-logs/**
           if-no-files-found: warn
 
-  # Stage 4: публікація пакету після успішних інтеграційних тестів.
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: integration-tests
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Build project
+        shell: bash
+        run: |
+          mkdir -p target/ci-logs
+          set -o pipefail
+          mvn -B package -DskipTests -Djacoco.skip=true -Dcheckstyle.skip=true | tee target/ci-logs/build.log
+
+      - name: Upload build artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifacts
+          path: target/*.jar
+          if-no-files-found: warn
+
+      - name: Upload build logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-logs
+          path: target/ci-logs/**
+          if-no-files-found: warn
+
   publish:
     name: Publish Package
-    needs: integration-tests
+    needs: build
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -35,7 +35,9 @@ jobs:
           server-password: GITHUB_TOKEN
 
       # Крок 3: Публікація артефактів в GitHub Packages
+      # -DskipTests вимикає unit-тести (Surefire) та integration-тести (Failsafe)
+      # -Djacoco.skip=true вимикає JaCoCo перевірки покриття (тести вже пройшли в CI)
       - name: Publish to GitHub Packages
-        run: mvn --batch-mode deploy --file pom.xml -DskipTests
+        run: mvn --batch-mode deploy --file pom.xml -DskipTests -Djacoco.skip=true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ build/
 
 ### Mac OS ###
 .DS_Store
+
+### Claude ###
+.claude/

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Приклад Java-програми ведення показників електролічильників з використанням СКБД MongoDB
 
 ## Кроки для виконання
+
 1. Завантажте і встановіть Java Development Kit 17 (або новішу версію) для Windows.
 1. Завантажте Maven з https://dlcdn.apache.org/maven/maven-3/3.8.9/binaries/apache-maven-3.8.9-bin.zip і розпакуйте його на локальний комп'ютер.
 1. В Windows в параметрах системи додайте системну змінну `MAVEN_HOME=<шлях до папки з Maven>`
 1. В Windows в параметрах системи додайте `;<шлях до папки з Maven>\bin` в системну змінну PATH.
 1. Встановіть СКБД MongoDB Community Server, вибравши варіант установки Complete → "Run service as Network Service user".
 1. Встановіть MongoDB Compass (GUI).
-1. Створіть базу даних `energy-db` і колекцію в ній `energy-readings`.
-1. Зберіть програму використовуючи команду: `mvn clean install`.
-1. Запустіть програму за допомогою команди: `mvn exec:java`.
-1. Якщо термінал відображає знаки питання "?" замість українських символів, зконфігуруйте термінал на відображення шрифту в форматі UTF-8 виконавши команду `chcp 65001`.
+1. Зберіть програму використовуючи команду: `mvn package`.
+1. Запустіть програму за допомогою команди: `mvn spring-boot:run`.
+1. Відкрийте браузер і перейдіть за адресою: `http://localhost:8081`.
 
 ## Налаштування MONGO_URI
 
@@ -37,24 +37,67 @@ mongodb+srv://<db-username>:<db-password>@<cluster-url>/energy-db?retryWrites=tr
 Windows Command Prompt:
 ```
 set MONGO_URI=mongodb+srv://db-username:db-password@cluster0.abcde.mongodb.net/energy-db?retryWrites=true^&w=majority
-mvn exec:java
+mvn spring-boot:run
 ```
 
 PowerShell:
 ```
 $env:MONGO_URI="mongodb+srv://db-username:db-password@cluster0.abcde.mongodb.net/energy-db?retryWrites=true&w=majority"
-mvn exec:java
+mvn spring-boot:run
 ```
 
 Linux/macOS:
 ```
 export MONGO_URI="mongodb+srv://db-username:db-password@cluster0.abcde.mongodb.net/energy-db?retryWrites=true&w=majority"
-mvn exec:java
+mvn spring-boot:run
 ```
 
 > Примітка: якщо пароль містить спеціальні символи, їх потрібно URL-кодувати в connection string. Наприклад, символ `@` потрібно замінити на `%40`.
 
-## Результати виконання програми
+## Запуск тестів
+
+### Unit-тести
+
+Запускає unit-тести з перевіркою покриття коду (мінімум 75% рядків):
+
+```
+mvn package
+```
+
+### Інтеграційні тести
+
+Запускає інтеграційні тести з реальною MongoDB у тимчасовому Docker-контейнері (Testcontainers).
+Потребує встановленого та запущеного Docker.
+
+```
+mvn verify -DskipUTs=true
+```
+
+> На Windows з Docker Desktop необхідно увімкнути параметр "Expose daemon on tcp://localhost:2375 without TLS" у налаштуваннях Docker Desktop → General.
+
+## Правила покриття коду
+
+| Тип тестів | Область | Мінімальне покриття |
+|---|---|---|
+| Unit (Surefire) | Весь проєкт (BUNDLE) | 75% рядків |
+| Integration (Failsafe) | `EnergyReading` | 100% рядків |
+| Integration (Failsafe) | `EnergyReadingController` | 100% рядків |
+
+## CI/CD Pipeline
+
+```
+Static Analysis → Build (unit tests) → Integration Tests → Publish Package
+```
+
+| Крок | Що робить |
+|---|---|
+| Static Analysis | Перевірка стилю коду (Checkstyle) |
+| Build | Збірка проєкту, unit-тести, JaCoCo coverage ≥ 75% |
+| Integration Tests | Запуск Testcontainers + MockMvc, JaCoCo coverage = 100% для EnergyReading і EnergyReadingController |
+| Publish Package | Публікація артефакту в GitHub Packages (тести не повторюються) |
+
+## Результати запуску застосунку
+
 ```
   .   ____          _            __ _ _
  /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
@@ -64,45 +107,34 @@ mvn exec:java
  =========|_|==============|___/=/_/_/_/
  :: Spring Boot ::                (v2.5.4)
 
-INFO --- [lication.main()] org.energy.EnergyApplication : Starting EnergyApplication
-INFO --- [lication.main()] org.mongodb.driver.cluster   : Adding discovered server cluster0.mongodb.net:27017
-INFO --- [lication.main()] org.mongodb.driver.cluster   : Discovered replica set primary cluster0.mongodb.net:27017
-INFO --- [lication.main()] org.energy.EnergyApplication : Started EnergyApplication in 2.1 seconds
-1. Додати показники з CSV-файлу
-2. Подивитись показники
-3. Видалити показники
-4. Вихід
-Введіть номер команди (1-4): 1
-12 документів з показниками електролічильників завантажено з CSV.
-1. Додати показники з CSV-файлу
-2. Подивитись показники
-3. Видалити показники
-4. Вихід
-Введіть номер команди (1-4): 2
-Знайдено 12 документів показників:
-EnergyReading { id="..."
- consumer="Коваленко Іван Петрович"
- supplier="ЕнергоПостач"
- technician="Сидоренко Олег Миколайович"
- reading_date="2024-09-01"
- reading_value="1250.5"
- address="м. Київ, вул. Шевченка, 12, кв. 5"
- tariff_zone="Денна"
- price_per_kwh="2.85"
- experience_years="5"
- meter_type="Електронний"
-}
-... (всього 12 документів)
-1. Додати показники з CSV-файлу
-2. Подивитись показники
-3. Видалити показники
-4. Вихід
-Введіть номер команди (1-4): 3
-Показники видалено.
-1. Додати показники з CSV-файлу
-2. Подивитись показники
-3. Видалити показники
-4. Вихід
-Введіть номер команди (1-4): 4
-INFO --- [ionShutdownHook] org.mongodb.driver.connection : Closed connection to cluster0.mongodb.net:27017
+INFO --- [main] org.energy.EnergyApplication : Starting EnergyApplication
+INFO --- [main] org.mongodb.driver.cluster   : Adding discovered server localhost:27017
+INFO --- [main] org.energy.EnergyApplication : Started EnergyApplication in 2.3 seconds (JVM running for 3.1)
+```
+
+Після запуску відкрийте браузер за адресою: `http://localhost:8081`
+
+## Результати збірки
+
+```
+[INFO] --- surefire:3.5.1:test (default-test) @ energy2026 ---
+[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0
+[INFO]
+[INFO] --- jacoco:0.8.14:check (check) @ energy2026 ---
+[INFO] All coverage checks have been met.
+[INFO]
+[INFO] BUILD SUCCESS
+```
+
+## Результати інтеграційних тестів
+
+```
+[INFO] --- failsafe:3.5.1:integration-test (default) @ energy2026 ---
+[INFO] Running org.energy.EnergyReadingFlowIntegrationTests
+[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
+[INFO]
+[INFO] --- jacoco:0.8.14:check (check-integration) @ energy2026 ---
+[INFO] All coverage checks have been met.
+[INFO]
+[INFO] BUILD SUCCESS
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.scm.id>github</project.scm.id>
+        <testcontainers.version>1.20.6</testcontainers.version>
+        <!-- Used to skip unit tests only (Surefire) while still running integration tests (Failsafe) -->
+        <skipUTs>false</skipUTs>
+        <argLine></argLine>
     </properties>
 
     <!-- SCM Information -->
@@ -28,6 +32,18 @@
         <url>https://github.com/Energy2026/Energy2026</url>
         <tag>HEAD</tag>
     </scm>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${testcontainers.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -52,6 +68,18 @@
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
             <version>5.12.0</version>
+        </dependency>
+
+        <!-- Testcontainers for integration tests -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mongodb</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -103,33 +131,75 @@
                 </configuration>
             </plugin>
 
+            <!-- Unit tests only: excludes integration tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.1</version>
                 <configuration>
                     <useModulePath>false</useModulePath>
+                    <excludes>
+                        <exclude>**/*FlowIntegrationTests.java</exclude>
+                    </excludes>
+                    <skipTests>${skipUTs}</skipTests>
                 </configuration>
+            </plugin>
+
+            <!-- Integration tests only: includes *FlowIntegrationTests classes -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <includes>
+                        <include>**/*FlowIntegrationTests.java</include>
+                    </includes>
+                    <argLine>@{argLine}</argLine>
+                    <environmentVariables>
+                        <DOCKER_HOST>tcp://localhost:2375</DOCKER_HOST>
+                    </environmentVariables>
+                    <systemPropertyVariables>
+                        <api.version>1.54</api.version>
+                    </systemPropertyVariables>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.12</version>
+                <version>0.8.14</version>
                 <executions>
+                    <!-- Unit test coverage: prepare agent -->
                     <execution>
                         <id>prepare-agent</id>
                         <goals>
                             <goal>prepare-agent</goal>
                         </goals>
+                        <configuration>
+                            <destFile>${project.build.directory}/jacoco.exec</destFile>
+                        </configuration>
                     </execution>
+                    <!-- Unit test coverage: generate report -->
                     <execution>
                         <id>report</id>
                         <phase>test</phase>
                         <goals>
                             <goal>report</goal>
                         </goals>
+                        <configuration>
+                            <dataFile>${project.build.directory}/jacoco.exec</dataFile>
+                            <outputDirectory>${project.reporting.outputDirectory}/jacoco</outputDirectory>
+                        </configuration>
                     </execution>
+                    <!-- Unit test coverage: enforce 75% minimum -->
                     <execution>
                         <id>check</id>
                         <phase>package</phase>
@@ -137,6 +207,8 @@
                             <goal>check</goal>
                         </goals>
                         <configuration>
+                            <skip>${skipUTs}</skip>
+                            <dataFile>${project.build.directory}/jacoco.exec</dataFile>
                             <rules>
                                 <rule>
                                     <element>BUNDLE</element>
@@ -145,6 +217,56 @@
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
                                             <minimum>0.75</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                    <!-- Integration test coverage: prepare agent -->
+                    <execution>
+                        <id>prepare-agent-integration</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>prepare-agent-integration</goal>
+                        </goals>
+                        <configuration>
+                            <destFile>${project.build.directory}/jacoco-it.exec</destFile>
+                        </configuration>
+                    </execution>
+                    <!-- Integration test coverage: generate report -->
+                    <execution>
+                        <id>report-integration</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>report-integration</goal>
+                        </goals>
+                        <configuration>
+                            <dataFile>${project.build.directory}/jacoco-it.exec</dataFile>
+                            <outputDirectory>${project.reporting.outputDirectory}/jacoco-it</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <!-- Integration test coverage: enforce 100% for EnergyReading and EnergyReadingController -->
+                    <execution>
+                        <id>check-integration</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <dataFile>${project.build.directory}/jacoco-it.exec</dataFile>
+                            <rules>
+                                <rule>
+                                    <element>CLASS</element>
+                                    <includes>
+                                        <include>org/energy/EnergyReading</include>
+                                        <include>org/energy/EnergyReadingController</include>
+                                    </includes>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>1.0</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/pom.xml
+++ b/pom.xml
@@ -155,12 +155,6 @@
                         <include>**/*FlowIntegrationTests.java</include>
                     </includes>
                     <argLine>@{argLine}</argLine>
-                    <environmentVariables>
-                        <DOCKER_HOST>tcp://localhost:2375</DOCKER_HOST>
-                    </environmentVariables>
-                    <systemPropertyVariables>
-                        <api.version>1.54</api.version>
-                    </systemPropertyVariables>
                 </configuration>
                 <executions>
                     <execution>
@@ -296,4 +290,39 @@
             </plugin>
         </plugins>
     </build>
+
+    <!--
+        Активується локально (коли змінна середовища CI не встановлена).
+        На GitHub Actions CI=true завжди присутня, тому цей профіль там не діє.
+        Налаштовує Failsafe для роботи з Docker Desktop на Windows:
+        - DOCKER_HOST: TCP замість named pipe (потребує увімкнення у Docker Desktop → General)
+        - api.version: Docker Desktop 4.x відхиляє запити з версією API нижче ~1.40
+    -->
+    <profiles>
+        <profile>
+            <id>local-docker-desktop</id>
+            <activation>
+                <property>
+                    <name>!env.CI</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>3.5.1</version>
+                        <configuration>
+                            <environmentVariables>
+                                <DOCKER_HOST>tcp://localhost:2375</DOCKER_HOST>
+                            </environmentVariables>
+                            <systemPropertyVariables>
+                                <api.version>1.54</api.version>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.data.mongodb.uri=${MONGO_URI:mongodb://localhost:27017/energy-db}
+server.port=8081

--- a/src/test/java/org/energy/EnergyReadingFlowIntegrationTests.java
+++ b/src/test/java/org/energy/EnergyReadingFlowIntegrationTests.java
@@ -1,0 +1,179 @@
+package org.energy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Інтеграційні тести для перевірки повного HTTP-потоку
+ * через EnergyReadingController із реальною MongoDB у тимчасовому контейнері.
+ * Перевіряє 100% покриття EnergyReading та EnergyReadingController.
+ */
+@Testcontainers
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+class EnergyReadingFlowIntegrationTests {
+
+    @Container
+    static MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:6.0");
+
+    @DynamicPropertySource
+    static void mongoProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.mongodb.uri", mongoDBContainer::getReplicaSetUrl);
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EnergyReadingRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository.deleteAll();
+    }
+
+    @Test
+    void viewReadings_whenEmpty_showsReadingsView() throws Exception {
+        mockMvc.perform(get("/"))
+            .andExpect(status().isOk())
+            .andExpect(view().name("readings"))
+            .andExpect(model().attributeExists("readings"));
+    }
+
+    @Test
+    void showAddForm_returnsAddViewWithEmptyReading() throws Exception {
+        mockMvc.perform(get("/add"))
+            .andExpect(status().isOk())
+            .andExpect(view().name("add"))
+            .andExpect(model().attributeExists("reading"));
+    }
+
+    @Test
+    void addReading_savesToDatabaseAndRedirects() throws Exception {
+        mockMvc.perform(post("/add")
+            .param("consumer", "Споживач Тест")
+            .param("supplier", "Постачальник Тест")
+            .param("technician", "Технік Тест")
+            .param("reading_date", "2024-01-01")
+            .param("reading_value", "1000.0")
+            .param("address", "м. Київ, вул. Тестова, 1")
+            .param("tariff_zone", "Денна")
+            .param("price_per_kwh", "2.85")
+            .param("experience_years", "5")
+            .param("meter_type", "Електронний"))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/"));
+
+        List<EnergyReading> all = repository.findAll();
+        assertEquals(1, all.size());
+        assertEquals("Споживач Тест", all.get(0).getConsumer());
+    }
+
+    @Test
+    void viewReadings_withData_showsAllReadingsInModel() throws Exception {
+        repository.save(new EnergyReading(
+            "Споживач", "Постачальник", "Технік",
+            "2024-01-01", "500.0", "м. Київ, вул. Хрещатик, 1",
+            "Нічна", "1.32", "3", "Індукційний"
+        ));
+
+        mockMvc.perform(get("/"))
+            .andExpect(status().isOk())
+            .andExpect(view().name("readings"))
+            .andExpect(model().attributeExists("readings"));
+    }
+
+    @Test
+    void deleteReading_removesFromDatabaseAndRedirects() throws Exception {
+        EnergyReading saved = repository.save(new EnergyReading(
+            "Споживач", "Постачальник", "Технік",
+            "2024-01-01", "500.0", "м. Київ, вул. Хрещатик, 1",
+            "Нічна", "1.32", "3", "Індукційний"
+        ));
+
+        mockMvc.perform(post("/delete/" + saved.getId()))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/"));
+
+        assertTrue(repository.findAll().isEmpty());
+    }
+
+    @Test
+    void energyReading_noArgConstructorAndSetters() {
+        EnergyReading reading = new EnergyReading();
+
+        assertNull(reading.getId());
+        assertNull(reading.getConsumer());
+
+        reading.setId("test-id");
+        reading.setConsumer("Споживач");
+        reading.setSupplier("Постачальник");
+        reading.setTechnician("Технік");
+        reading.setReading_date("2024-01-01");
+        reading.setReading_value("100.0");
+        reading.setAddress("Адреса");
+        reading.setTariff_zone("Денна");
+        reading.setPrice_per_kwh("2.85");
+        reading.setExperience_years("5");
+        reading.setMeter_type("Електронний");
+
+        assertEquals("test-id", reading.getId());
+        assertEquals("Споживач", reading.getConsumer());
+        assertEquals("Постачальник", reading.getSupplier());
+        assertEquals("Технік", reading.getTechnician());
+        assertEquals("2024-01-01", reading.getReading_date());
+        assertEquals("100.0", reading.getReading_value());
+        assertEquals("Адреса", reading.getAddress());
+        assertEquals("Денна", reading.getTariff_zone());
+        assertEquals("2.85", reading.getPrice_per_kwh());
+        assertEquals("5", reading.getExperience_years());
+        assertEquals("Електронний", reading.getMeter_type());
+    }
+
+    @Test
+    void energyReading_fullConstructorAndToString() {
+        EnergyReading reading = new EnergyReading(
+            "Споживач", "Постачальник", "Технік",
+            "2024-01-01", "100.0", "Адреса",
+            "Денна", "2.85", "5", "Електронний"
+        );
+
+        assertEquals("Споживач", reading.getConsumer());
+        assertEquals("Постачальник", reading.getSupplier());
+        assertEquals("Технік", reading.getTechnician());
+        assertEquals("2024-01-01", reading.getReading_date());
+        assertEquals("100.0", reading.getReading_value());
+        assertEquals("Адреса", reading.getAddress());
+        assertEquals("Денна", reading.getTariff_zone());
+        assertEquals("2.85", reading.getPrice_per_kwh());
+        assertEquals("5", reading.getExperience_years());
+        assertEquals("Електронний", reading.getMeter_type());
+
+        String text = reading.toString();
+        assertNotNull(text);
+        assertTrue(text.contains("EnergyReading"));
+        assertTrue(text.contains("consumer=\"Споживач\""));
+        assertTrue(text.contains("supplier=\"Постачальник\""));
+    }
+}


### PR DESCRIPTION
### What does this PR do?
Adds end-to-end integration coverage for the web energy reading flow using MockMvc and Testcontainers MongoDB, including GET /, GET /add, POST /add, and POST /delete/{id}.
It also updates the Maven build to run integration tests with Failsafe, generate separate JaCoCo integration reports, and fail verify unless integration tests achieve 100% line coverage for EnergyReading and EnergyReadingController.

### Related issue
#19 
### Description for the changelog

``` 
Add Mongo-backed integration tests for the energy reading web flow and enforce full integration coverage for EnergyReading and EnergyReadingController.
```
