### PR TITLE
Containerize Energy2026 application using Docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,3 +241,13 @@ jobs:
       packages: write
     uses: ./.github/workflows/maven-publish.yml
     secrets: inherit
+
+  # Етап 6: опублікувати Docker-образ лише після успішного завершення етапу збірки
+  publish-docker:
+    name: Publish Docker Image
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/docker-publish.yml
+    secrets: inherit

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,68 @@
+name: Docker Publish
+
+on:
+  workflow_call:
+
+  workflow_dispatch:
+
+jobs:
+  # Публікує образ Docker-контейнера до GitHub Container Registry.
+  publish-image:
+    name: Build and Push
+    runs-on: ubuntu-latest
+    # Надає доступ до коду репозиторію та публікації пакета.
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      # Крок 1: отримання коду з репозиторію.
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Крок 2: отримання версії проєкту безпосередньо з pom.xml для тега образу.
+      - name: Read project version
+        id: project-version
+        shell: bash
+        run: |
+          VERSION=$(grep -oPm1 '(?<=<version>)[^<]+' pom.xml | tr '[:upper:]' '[:lower:]')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if [[ "$VERSION" != *"snapshot"* ]]; then
+            echo "publish_latest=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish_latest=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Крок 3: налаштування Buildx для збирання образу Docker-контейнера.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Крок 4: автентифікація в GitHub Container Registry.
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Крок 5: формування назви образу Docker-контейнера, тегів і метаданих.
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/energy2026
+          tags: |
+            type=ref,event=branch
+            type=sha
+            type=raw,value=${{ steps.project-version.outputs.version }},enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.ref_name == github.event.repository.default_branch && steps.project-version.outputs.publish_latest == 'true' }}
+
+      # Крок 6: збирання та публікація образу Docker-контейнера.
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./deploy/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,0 +1,32 @@
+# Етап збірки застосунку за допомогою Maven і Java 17
+FROM maven:3.9.9-eclipse-temurin-17 AS build
+
+# Робоча директорія для збірки
+WORKDIR /app
+
+# Копіюємо файли збірки і вихідний код застосунку
+COPY pom.xml ./
+COPY checkstyle.xml ./
+COPY src ./src
+
+# Пакуємо застосунок і копіюємо runtime-залежності окремо
+RUN mvn -B -DskipTests package dependency:copy-dependencies
+
+# Мінімальний runtime-образ з Java 17
+FROM eclipse-temurin:17-jre
+
+# Робоча директорія контейнера
+WORKDIR /app
+
+# Копіюємо зібраний jar файл і залежності з етапу збірки
+COPY --from=build /app/target/*.jar ./app.jar
+COPY --from=build /app/target/dependency ./lib
+
+# Значення порту за замовчуванням для локального запуску
+ENV PORT=8081
+
+# Порт, який слухає застосунок
+EXPOSE 8081
+
+# Старт Spring Boot застосунку через main class і classpath
+CMD ["java", "-jar", "app.jar"]

--- a/deploy/Dockerfile.dockerignore
+++ b/deploy/Dockerfile.dockerignore
@@ -1,0 +1,7 @@
+.git
+.github
+.vscode
+.devcontainer
+target
+README.md
+deploy/render.yaml


### PR DESCRIPTION
### What does this PR do?
Adds Docker containerization and publishing for the Energy2026 application.
This PR introduces a multi-stage Docker build, a reusable GitHub Actions workflow to publish the image to GitHub Container Registry after a successful build, and README.md updates with local Docker build and run instructions.

### Related issue
#10 

### Description for the changelog

``` 
Add Docker image build and GHCR publish workflow for the Energy2026 application.
```
