### PR TITLE
Add E2E UI tests and GitHub Action to run tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,9 +252,9 @@ jobs:
     uses: ./.github/workflows/docker-publish.yml
     secrets: inherit
 
-  # Етап 7: розгорнути застосунок на Render.com у межах pull request для E2E-тестування.
+  # Етап 7: виконати деплой у Render для pull request після успішної публікації образу Docker-контейнера.
   deploy-render-pr:
-    name: Deploy to Render (PR)
+    name: Deploy Render PR
     needs: publish-docker
     if: github.event_name == 'pull_request'
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
         run: |
           mkdir -p target/ci-logs
           set -o pipefail
-          mvn -B verify -DskipUTs=true -Dcheckstyle.skip=true | tee target/ci-logs/integration-tests.log
+          mvn -B verify -DskipUnitTests=true -Dcheckstyle.skip=true | tee target/ci-logs/integration-tests.log
 
       - name: Upload integration test reports
         if: always()
@@ -251,3 +251,24 @@ jobs:
       packages: write
     uses: ./.github/workflows/docker-publish.yml
     secrets: inherit
+
+  # Етап 7: розгорнути застосунок на Render.com у межах pull request для E2E-тестування.
+  deploy-render-pr:
+    name: Deploy to Render (PR)
+    needs: publish-docker
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/render-deploy.yml
+    secrets: inherit
+
+  # Етап 8: запустити E2E UI-тести проти програми, яка була успішно розгорнута на Render.com
+  e2e-ui-tests:
+    name: E2E UI Tests
+    needs: deploy-render-pr
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/run-e2e-test.yml
+    with:
+      application_url: ${{ needs.deploy-render-pr.outputs.application_url }}

--- a/.github/workflows/render-deploy.yml
+++ b/.github/workflows/render-deploy.yml
@@ -33,6 +33,7 @@ jobs:
     if: >
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'workflow_call' ||
+      github.event_name == 'pull_request' ||
       (github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.head_branch == 'main')
     # Надає доступ до читання вмісту репозиторію.
@@ -59,18 +60,19 @@ jobs:
             version="$(grep -oPm1 '(?<=<version>)[^<]+' pom.xml | tr '[:upper:]' '[:lower:]')"
             echo "image_url=${image_repo}:${version}" >> "$GITHUB_OUTPUT"
 
-          elif [[ "${{ github.event_name }}" == "workflow_call" ]]; then
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             # Для виклику з CI в pull request формуємо тег у форматі pr-<номер PR>.
             pr_number="${{ github.event.pull_request.number }}"
             if [[ -z "$pr_number" ]]; then
-              echo "image_url=${image_repo}:latest" >> "$GITHUB_OUTPUT"
-            else
-              echo "image_url=${image_repo}:pr-${pr_number}" >> "$GITHUB_OUTPUT"
+              # Якщо номер PR недоступний у контексті, деплой продовжувати не можна.
+              printf 'Unable to resolve pull request number for pull_request context.\n' >&2
+              exit 1
             fi
+            echo "image_url=${image_repo}:pr-${pr_number}" >> "$GITHUB_OUTPUT"
 
           else
-            # Для ручного запуску використовуємо тег, переданий через input image_tag.
-            echo "image_url=${image_repo}:${{ inputs.image_tag }}" >> "$GITHUB_OUTPUT"
+            # Для ручного запуску або workflow_call використовуємо тег image_tag (або latest).
+            echo "image_url=${image_repo}:${{ inputs.image_tag || 'latest' }}" >> "$GITHUB_OUTPUT"
           fi
 
       # Крок 3: перевірка наявності обов'язкових секретів GitHub Actions для Render.

--- a/.github/workflows/render-deploy.yml
+++ b/.github/workflows/render-deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to Render
+name: Render Deploy
 
 on:
   # Дозволяє викликати workflow з інших workflow, наприклад із CI для деплою з pull request.
@@ -8,74 +8,152 @@ on:
         description: Deployed application base URL
         value: ${{ jobs.deploy.outputs.application_url }}
 
-  # Дозволяє вручну запустити деплой.
+  # Дозволяє вручну запустити деплой із вказаним тегом образу Docker-контейнера.
   workflow_dispatch:
+    inputs:
+      image_tag:
+        description: Docker image tag to deploy from GHCR
+        required: false
+        default: latest
+        type: string
+
+  # Запускає деплой після успішного завершення workflow CI для гілки main.
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
 
 jobs:
+  # Виконує деплой застосунку в Render із вказаним образом Docker-контейнера.
   deploy:
     name: Deploy to Render
     runs-on: ubuntu-latest
     outputs:
       application_url: ${{ steps.service.outputs.application_url }}
+    # Реальний деплой виконується для виклику з pull request, ручного запуску або після успішного CI в main.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'workflow_call' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_branch == 'main')
+    # Надає доступ до читання вмісту репозиторію.
+    permissions:
+      contents: read
 
     steps:
-      # Крок 1: ініціюємо новий деплой сервісу через Render API.
-      - name: Trigger Render deploy
-        id: trigger
+      # Крок 1: отримання коду для читання версії з pom.xml після workflow_run від CI в main.
+      - name: Checkout repository
+        if: github.event_name == 'workflow_run'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      # Крок 2: визначення адреси образу Docker-контейнера для деплою.
+      - name: Resolve deploy settings
+        id: settings
+        shell: bash
+        run: |
+          image_repo="ghcr.io/$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')/energy2026"
+
+          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            # Для автодеплою після CI в main використовуємо версію з pom.xml.
+            version="$(grep -oPm1 '(?<=<version>)[^<]+' pom.xml | tr '[:upper:]' '[:lower:]')"
+            echo "image_url=${image_repo}:${version}" >> "$GITHUB_OUTPUT"
+
+          elif [[ "${{ github.event_name }}" == "workflow_call" ]]; then
+            # Для виклику з CI в pull request формуємо тег у форматі pr-<номер PR>.
+            pr_number="${{ github.event.pull_request.number }}"
+            if [[ -z "$pr_number" ]]; then
+              echo "image_url=${image_repo}:latest" >> "$GITHUB_OUTPUT"
+            else
+              echo "image_url=${image_repo}:pr-${pr_number}" >> "$GITHUB_OUTPUT"
+            fi
+
+          else
+            # Для ручного запуску використовуємо тег, переданий через input image_tag.
+            echo "image_url=${image_repo}:${{ inputs.image_tag }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Крок 3: перевірка наявності обов'язкових секретів GitHub Actions для Render.
+      - name: Validate Render secrets
         shell: bash
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID }}
         run: |
+          missing=()
+
+          [[ -z "$RENDER_API_KEY" ]] && missing+=("RENDER_API_KEY")
+          [[ -z "$RENDER_SERVICE_ID" ]] && missing+=("RENDER_SERVICE_ID")
+
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing required GitHub Actions secrets: %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+      # Крок 4: запуск нового деплою в Render із заданим образом Docker-контейнера.
+      - name: Trigger Render deploy
+        id: deploy
+        shell: bash
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID }}
+          IMAGE_URL: ${{ steps.settings.outputs.image_url }}
+        run: |
           response="$(
-            curl --silent --show-error --fail-with-body \
+            curl --silent --show-error \
               --request POST \
               --url "https://api.render.com/v1/services/${RENDER_SERVICE_ID}/deploys" \
               --header "Authorization: Bearer ${RENDER_API_KEY}" \
               --header "Content-Type: application/json" \
-              --data '{}'
+              --data "$(jq -cn --arg imageUrl "$IMAGE_URL" '{imageUrl: $imageUrl}')"
           )"
+          printf 'Render API response: %s\n' "$response"
+
           deploy_id="$(jq -r '.id // empty' <<<"$response")"
           if [[ -z "$deploy_id" ]]; then
-            printf 'Unable to extract deploy ID from Render response.\n%s\n' "$response" >&2
+            printf 'Render deploy response did not include a deploy id.\n%s\n' "$response" >&2
             exit 1
           fi
-          printf 'Triggered Render deploy: %s\n' "$deploy_id"
+
           echo "deploy_id=${deploy_id}" >> "$GITHUB_OUTPUT"
 
-      # Крок 2: чекаємо, поки Render завершить деплой (статус live або failed).
-      - name: Wait for deploy to complete
+      # Крок 5: очікування завершення деплою та перевірка фінального статусу.
+      - name: Wait for Render deploy
         shell: bash
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
           RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID }}
-          DEPLOY_ID: ${{ steps.trigger.outputs.deploy_id }}
+          DEPLOY_ID: ${{ steps.deploy.outputs.deploy_id }}
         run: |
-          for attempt in {1..60}; do
+          for attempt in {1..40}; do
             response="$(
               curl --silent --show-error --fail-with-body \
                 --request GET \
                 --url "https://api.render.com/v1/services/${RENDER_SERVICE_ID}/deploys/${DEPLOY_ID}" \
                 --header "Authorization: Bearer ${RENDER_API_KEY}"
             )"
+
             status="$(jq -r '.status // empty' <<<"$response")"
-            printf 'Deploy %s status on attempt %d: %s\n' "$DEPLOY_ID" "$attempt" "$status"
+            printf 'Render deploy %s status: %s\n' "$DEPLOY_ID" "$status"
+
             case "$status" in
               live)
-                printf 'Deploy %s completed successfully.\n' "$DEPLOY_ID"
                 exit 0
                 ;;
-              build_failed|update_failed|canceled|deactivated)
-                printf 'Deploy %s failed with status: %s\n' "$DEPLOY_ID" "$status" >&2
+              build_failed|update_failed|canceled|cancelled|failed|deactivated)
+                printf 'Render deploy %s finished with failing status: %s\n' "$DEPLOY_ID" "$status" >&2
+                printf '%s\n' "$response" >&2
                 exit 1
                 ;;
             esac
-            sleep 10
+
+            sleep 15
           done
+
           printf 'Timed out waiting for Render deploy %s to finish.\n' "$DEPLOY_ID" >&2
           exit 1
 
-      # Крок 3: отримуємо URL запущеного застосунку через Render API.
+      # Крок 6: отримуємо URL запущеного застосунку через Render API.
       - name: Resolve deployed application URL
         id: service
         shell: bash

--- a/.github/workflows/render-deploy.yml
+++ b/.github/workflows/render-deploy.yml
@@ -1,0 +1,109 @@
+name: Deploy to Render
+
+on:
+  # Дозволяє викликати workflow з інших workflow, наприклад із CI для деплою з pull request.
+  workflow_call:
+    outputs:
+      application_url:
+        description: Deployed application base URL
+        value: ${{ jobs.deploy.outputs.application_url }}
+
+  # Дозволяє вручну запустити деплой.
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Deploy to Render
+    runs-on: ubuntu-latest
+    outputs:
+      application_url: ${{ steps.service.outputs.application_url }}
+
+    steps:
+      # Крок 1: ініціюємо новий деплой сервісу через Render API.
+      - name: Trigger Render deploy
+        id: trigger
+        shell: bash
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID }}
+        run: |
+          response="$(
+            curl --silent --show-error --fail-with-body \
+              --request POST \
+              --url "https://api.render.com/v1/services/${RENDER_SERVICE_ID}/deploys" \
+              --header "Authorization: Bearer ${RENDER_API_KEY}" \
+              --header "Content-Type: application/json" \
+              --data '{}'
+          )"
+          deploy_id="$(jq -r '.id // empty' <<<"$response")"
+          if [[ -z "$deploy_id" ]]; then
+            printf 'Unable to extract deploy ID from Render response.\n%s\n' "$response" >&2
+            exit 1
+          fi
+          printf 'Triggered Render deploy: %s\n' "$deploy_id"
+          echo "deploy_id=${deploy_id}" >> "$GITHUB_OUTPUT"
+
+      # Крок 2: чекаємо, поки Render завершить деплой (статус live або failed).
+      - name: Wait for deploy to complete
+        shell: bash
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID }}
+          DEPLOY_ID: ${{ steps.trigger.outputs.deploy_id }}
+        run: |
+          for attempt in {1..60}; do
+            response="$(
+              curl --silent --show-error --fail-with-body \
+                --request GET \
+                --url "https://api.render.com/v1/services/${RENDER_SERVICE_ID}/deploys/${DEPLOY_ID}" \
+                --header "Authorization: Bearer ${RENDER_API_KEY}"
+            )"
+            status="$(jq -r '.status // empty' <<<"$response")"
+            printf 'Deploy %s status on attempt %d: %s\n' "$DEPLOY_ID" "$attempt" "$status"
+            case "$status" in
+              live)
+                printf 'Deploy %s completed successfully.\n' "$DEPLOY_ID"
+                exit 0
+                ;;
+              build_failed|update_failed|canceled|deactivated)
+                printf 'Deploy %s failed with status: %s\n' "$DEPLOY_ID" "$status" >&2
+                exit 1
+                ;;
+            esac
+            sleep 10
+          done
+          printf 'Timed out waiting for Render deploy %s to finish.\n' "$DEPLOY_ID" >&2
+          exit 1
+
+      # Крок 3: отримуємо URL запущеного застосунку через Render API.
+      - name: Resolve deployed application URL
+        id: service
+        shell: bash
+        env:
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID }}
+        run: |
+          response="$(
+            curl --silent --show-error --fail-with-body \
+              --request GET \
+              --url "https://api.render.com/v1/services/${RENDER_SERVICE_ID}" \
+              --header "Authorization: Bearer ${RENDER_API_KEY}"
+          )"
+
+          application_url="$(
+            jq -r '
+              .service.serviceDetails.url //
+              .serviceDetails.url //
+              .service.url //
+              .url //
+              empty
+            ' <<<"$response"
+          )"
+
+          if [[ -z "$application_url" ]]; then
+            printf 'Unable to resolve deployed application URL from Render service response.\n%s\n' "$response" >&2
+            exit 1
+          fi
+
+          printf 'Resolved application URL: %s\n' "$application_url"
+          echo "application_url=${application_url}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/run-e2e-test.yml
+++ b/.github/workflows/run-e2e-test.yml
@@ -1,0 +1,70 @@
+name: E2E UI Tests Run
+
+on:
+  # Дозволяє викликати workflow з інших workflow, передаючи URL уже розгорнутого застосунку.
+  workflow_call:
+    inputs:
+      application_url:
+        description: Deployed application base URL for UI tests
+        required: true
+        type: string
+  # Дозволяє вручну запустити E2E UI-тести проти вказаного deployed URL.
+  workflow_dispatch:
+    inputs:
+      application_url:
+        description: Deployed application base URL for UI tests
+        required: true
+        type: string
+
+jobs:
+  # Виконує happy-path E2E UI-тести в Selenium Chromium проти вже розгорнутого застосунку.
+  e2e-ui-tests:
+    name: Run E2E UI Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      selenium:
+        image: selenium/standalone-chromium:latest
+        ports:
+          - 4444:4444
+
+    steps:
+      # Крок 1: отримання коду репозиторію з E2E тестами та Maven-конфігурацією.
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Крок 2: налаштування Java та кешу Maven для запуску E2E UI тестів на runner.
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      # Крок 3: підготовка директорій для логів, screenshot і відео тестового прогону.
+      - name: Prepare artifact directories
+        shell: bash
+        run: mkdir -p target/ci-logs target/e2e-artifacts/videos target/e2e-artifacts/screenshots
+
+      # Крок 4: запуск bootstrap-скрипта `workflows/scripts/run-e2e-test.sh`,
+      # який створює Selenium session, отримує CDP URL і запускає `mvn -P e2e-ui`.
+      - name: Run E2E UI tests
+        shell: bash
+        env:
+          E2E_BASE_URL: ${{ inputs.application_url }}
+          E2E_ARTIFACTS_DIR: target/e2e-artifacts
+        run: |
+          chmod +x .github/workflows/scripts/run-e2e-test.sh
+          .github/workflows/scripts/run-e2e-test.sh
+
+      # Крок 5: завантаження E2E звітів, логів, screenshot і screencast як artifacts pipeline.
+      - name: Upload E2E reports and media
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-ui-test-artifacts
+          path: |
+            target/failsafe-reports/**
+            target/ci-logs/**
+            target/e2e-artifacts/**
+          if-no-files-found: warn

--- a/.github/workflows/scripts/run-e2e-test.sh
+++ b/.github/workflows/scripts/run-e2e-test.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Готуємо директорії для логів Maven і артефактів Playwright.
+mkdir -p target/ci-logs target/e2e-artifacts/videos target/e2e-artifacts/screenshots
+LOG_FILE="target/ci-logs/e2e-ui-tests.log"
+
+log() {
+  echo "$1" | tee -a "$LOG_FILE"
+}
+
+# Очищаємо лог на початку кожного прогону, щоб артефакт містив лише актуальний запуск.
+: > "$LOG_FILE"
+
+# Чекаємо, поки Selenium почне стабільно відповідати на /status після старту контейнера.
+for attempt in {1..90}; do
+  # Читаємо статус Grid з окремими timeout, щоб короткі мережеві збої не валили весь скрипт.
+  ready_response="$(
+    curl --silent --show-error \
+      --connect-timeout 2 \
+      --max-time 10 \
+      http://127.0.0.1:4444/status
+  )" || ready_response=""
+
+  # Якщо відповідь є, намагаємось витягнути прапорець готовності з JSON.
+  if [[ -n "$ready_response" ]]; then
+    ready="$(jq -r '.value.ready // false' <<<"$ready_response" 2>/dev/null)" || ready="false"
+  else
+    ready="false"
+  fi
+
+  # Коли Grid готовий, можна переходити до створення браузерної сесії.
+  if [[ "$ready" == "true" ]]; then
+    log "Selenium Grid reported ready on attempt ${attempt}."
+    break
+  fi
+
+  # Логуємо повторну спробу, щоб у CI було видно, чи є повільний старт Selenium.
+  log "Selenium Grid not ready on attempt ${attempt}."
+  sleep 2
+done
+
+# Якщо навіть після всіх спроб Selenium не готовий, завершуємо прогін явною помилкою.
+if [[ "${ready:-false}" != "true" ]]; then
+  log "Selenium Grid did not become ready in time."
+  exit 1
+fi
+
+# Відкриваємо Selenium session і дістаємо CDP endpoint для Playwright.
+SESSION_ID=""
+CDP_URL=""
+
+for attempt in {1..30}; do
+  # Тимчасовий файл потрібен, щоб окремо зчитати тіло відповіді і HTTP-код від curl.
+  tmp_response_file="$(mktemp)"
+  http_code="$(
+    curl --silent --show-error \
+      --connect-timeout 2 \
+      --max-time 15 \
+      --output "$tmp_response_file" \
+      --write-out "%{http_code}" \
+      --request POST \
+      --url http://127.0.0.1:4444/session \
+      --header "Content-Type: application/json" \
+      --data '{
+        "capabilities": {
+          "alwaysMatch": {
+            "browserName": "chrome",
+            "goog:chromeOptions": {
+              "args": ["--headless=new", "--disable-dev-shm-usage", "--no-sandbox"]
+            }
+          }
+        }
+      }'
+  )" || http_code="curl_failed"
+
+  # Читаємо JSON відповіді незалежно від того, успішний це статус чи ні.
+  response="$(cat "$tmp_response_file")"
+  rm -f "$tmp_response_file"
+
+  if [[ "$http_code" == "200" ]]; then
+    # Для успішної відповіді витягуємо id Selenium session і CDP URL браузера.
+    SESSION_ID="$(jq -r '.value.sessionId // empty' <<<"$response")"
+    CDP_URL="$(jq -r '.value.capabilities["se:cdp"] // empty' <<<"$response")"
+    if [[ -n "$SESSION_ID" && -n "$CDP_URL" ]]; then
+      log "Created Selenium session on attempt ${attempt}."
+      break
+    fi
+    # Іноді Selenium відповідає 200, але ще не повертає повні capabilities; це теж повторюємо.
+    log "Selenium session response on attempt ${attempt} did not contain session metadata."
+    log "$response"
+  else
+    # Для неуспішного статусу залишаємо в логах HTTP-код і відповідь сервера.
+    log "Selenium session creation attempt ${attempt} failed with status ${http_code}."
+    if [[ -n "$response" ]]; then
+      log "$response"
+    fi
+  fi
+
+  # Даємо Selenium короткий час на стабілізацію перед наступною спробою.
+  sleep 2
+done
+
+# Якщо не вдалося отримати session id або CDP URL, далі запускати Playwright немає сенсу.
+if [[ -z "$SESSION_ID" || -z "$CDP_URL" ]]; then
+  log "Unable to resolve Selenium session metadata after retries."
+  exit 1
+fi
+
+cleanup() {
+  if [[ -n "${SESSION_ID:-}" ]]; then
+    # Закриваємо Selenium session навіть після падіння Maven, щоб не залишати "висячі" браузери.
+    curl --silent --show-error --fail-with-body \
+      --request DELETE \
+      --url "http://127.0.0.1:4444/session/${SESSION_ID}" >/dev/null || true
+  fi
+}
+
+trap cleanup EXIT
+
+# Selenium повертає внутрішню адресу контейнера, тому переписуємо її на localhost runner-а.
+CDP_PATH="${CDP_URL#ws://*/}"
+export E2E_SELENIUM_CDP_URL="ws://127.0.0.1:4444/${CDP_PATH}"
+export E2E_ARTIFACTS_DIR="${E2E_ARTIFACTS_DIR:-target/e2e-artifacts}"
+
+# Логуємо ключові параметри перед стартом Maven, щоб легше діагностувати CI-запуск.
+log "Resolved Playwright CDP endpoint: ${E2E_SELENIUM_CDP_URL}"
+log "Starting Maven E2E UI test run."
+
+# Запускаємо Maven-профіль E2E UI і одночасно пишемо консольний вивід у CI-лог.
+set -o pipefail
+mvn -B -P e2e-ui -Dcheckstyle.skip=true -DskipUnitTests=true -DskipIntegrationTests=true verify \
+  | tee -a "$LOG_FILE"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: deploy/Dockerfile
+    ports:
+      - "8081:8081"
+    environment:
+      # Connects to your local MongoDB where existing data is stored.
+      # On Windows/Mac Docker Desktop, host.docker.internal resolves to the host machine.
+      MONGO_URI: mongodb://host.docker.internal:27017/energy-db
+      PORT: "8081"

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,11 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.scm.id>github</project.scm.id>
         <testcontainers.version>1.20.6</testcontainers.version>
-        <!-- Used to skip unit tests only (Surefire) while still running integration tests (Failsafe) -->
-        <skipUTs>false</skipUTs>
+        <playwright.version>1.55.0</playwright.version>
+        <!-- Used to skip specific test phases independently -->
+        <skipUnitTests>false</skipUnitTests>
+        <skipIntegrationTests>false</skipIntegrationTests>
+        <skipE2ETests>false</skipE2ETests>
         <argLine />
     </properties>
 
@@ -79,6 +82,12 @@
             <artifactId>mongodb</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.microsoft.playwright</groupId>
+            <artifactId>playwright</artifactId>
+            <version>${playwright.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <distributionManagement>
@@ -129,7 +138,7 @@
                 </configuration>
             </plugin>
 
-            <!-- Unit tests only: excludes integration tests -->
+            <!-- Unit tests only: excludes integration and E2E tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -138,8 +147,9 @@
                     <useModulePath>false</useModulePath>
                     <excludes>
                         <exclude>**/*FlowIntegrationTests.java</exclude>
+                        <exclude>**/*E2ETests.java</exclude>
                     </excludes>
-                    <skipTests>${skipUTs}</skipTests>
+                    <skipTests>${skipUnitTests}</skipTests>
                 </configuration>
             </plugin>
 
@@ -149,6 +159,7 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>3.5.1</version>
                 <configuration>
+                    <skipITs>${skipIntegrationTests}</skipITs>
                     <includes>
                         <include>**/*FlowIntegrationTests.java</include>
                     </includes>
@@ -199,7 +210,7 @@
                             <goal>check</goal>
                         </goals>
                         <configuration>
-                            <skip>${skipUTs}</skip>
+                            <skip>${skipUnitTests}</skip>
                             <dataFile>${project.build.directory}/jacoco.exec</dataFile>
                             <rules>
                                 <rule>
@@ -297,6 +308,35 @@
         - api.version: Docker Desktop 4.x відхиляє запити з версією API нижче ~1.40
     -->
     <profiles>
+        <profile>
+            <id>e2e-ui</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>3.5.1</version>
+                        <configuration>
+                            <useModulePath>false</useModulePath>
+                            <skipITs>${skipE2ETests}</skipITs>
+                            <includes>
+                                <include>**/*E2ETests.java</include>
+                            </includes>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>run-e2e-ui-tests</id>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
         <profile>
             <id>local-docker-desktop</id>
             <activation>

--- a/src/test/java/org/energy/EnergyReadingHappyPathE2ETests.java
+++ b/src/test/java/org/energy/EnergyReadingHappyPathE2ETests.java
@@ -1,0 +1,380 @@
+package org.energy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.options.ScreenshotType;
+import com.microsoft.playwright.options.WaitForSelectorState;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.util.List;
+import java.util.function.BooleanSupplier;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class EnergyReadingHappyPathE2ETests {
+
+    // Підтримуємо конфігурацію через JVM properties та environment variables,
+    // щоб один і той самий тест можна було запускати локально й у CI.
+    private static final String BASE_URL_PROPERTY = "e2e.base-url";
+    private static final String BASE_URL_ENV = "E2E_BASE_URL";
+    private static final String SELENIUM_CDP_URL_PROPERTY = "e2e.selenium-cdp-url";
+    private static final String SELENIUM_CDP_URL_ENV = "E2E_SELENIUM_CDP_URL";
+    private static final String ARTIFACTS_DIR_PROPERTY = "e2e.artifacts-dir";
+    private static final String ARTIFACTS_DIR_ENV = "E2E_ARTIFACTS_DIR";
+    private static final String PAGE_READY_TIMEOUT_MILLIS_PROPERTY = "e2e.page-ready-timeout-millis";
+    private static final String PAGE_READY_TIMEOUT_MILLIS_ENV = "E2E_PAGE_READY_TIMEOUT_MILLIS";
+    private static final String ENERGY_PAGE_TITLE = "Показники електролічильників";
+    private static final String RENDER_HOST_SUFFIX = ".onrender.com";
+    private static final int WAIT_TIMEOUT_MILLIS = 15000;
+    private static final int POLL_INTERVAL_MILLIS = 250;
+    private static final int DEFAULT_PAGE_READY_TIMEOUT_MILLIS = 180000;
+    private static final int DEFAULT_TIMEOUT_MILLIS = 30000;
+    private static final int RENDER_TIMEOUT_MILLIS = 180000;
+    private static final int VIEWPORT_WIDTH = 1440;
+    private static final int VIEWPORT_HEIGHT = 1200;
+    private static final int VIDEO_WIDTH = 1280;
+    private static final int VIDEO_HEIGHT = 720;
+
+    private String baseUrl;
+    private String seleniumCdpUrl;
+    private int pageReadyTimeoutMillis;
+    private Path artifactsDir;
+    private Path videosDir;
+    private Path screenshotsDir;
+    private Playwright playwright;
+    private Browser browser;
+    private BrowserContext browserContext;
+    private Page page;
+    private String createdConsumer;
+
+    // Ініціалізуємо Playwright, директорії артефактів і браузерне оточення перед кожним тестом.
+    @BeforeEach
+    void setUp() {
+        baseUrl = resolveBaseUrl();
+
+        // Для E2E URL є обов'язковим, тому відсутність конфігурації вважаємо помилкою тестового запуску.
+        if (baseUrl == null || baseUrl.isBlank()) {
+            throw new IllegalStateException("Set e2e.base-url or E2E_BASE_URL to run E2E UI tests.");
+        }
+        seleniumCdpUrl = resolveOptionalValue(SELENIUM_CDP_URL_PROPERTY, SELENIUM_CDP_URL_ENV);
+        pageReadyTimeoutMillis = resolvePageReadyTimeoutMillis();
+        artifactsDir = resolveArtifactsDir();
+        videosDir = artifactsDir.resolve("videos");
+        screenshotsDir = artifactsDir.resolve("screenshots");
+        createDirectory(videosDir);
+        createDirectory(screenshotsDir);
+
+        playwright = Playwright.create();
+        browser = createBrowser();
+
+        // Записуємо відео кожного прогону, щоб у CI можна було відтворити UI-поведінку.
+        browserContext = browser.newContext(new Browser.NewContextOptions()
+            .setRecordVideoDir(videosDir)
+            .setRecordVideoSize(VIDEO_WIDTH, VIDEO_HEIGHT)
+            .setViewportSize(VIEWPORT_WIDTH, VIEWPORT_HEIGHT));
+        page = browserContext.newPage();
+        page.setDefaultTimeout(resolvePlaywrightTimeoutMillis());
+        page.setDefaultNavigationTimeout(resolvePlaywrightTimeoutMillis());
+    }
+
+    // Закриваємо браузерні ресурси та прибираємо створений тестом запис, якщо він залишився.
+    @AfterEach
+    void tearDown() {
+        if (page != null && createdConsumer != null) {
+            try {
+                // Якщо тест впав після створення запису, намагаємось прибрати тестові дані.
+                deleteEnergyRow(createdConsumer);
+            } catch (Exception exception) {
+                // Preserve the original test failure; cleanup is best effort.
+            } finally {
+                createdConsumer = null;
+            }
+        }
+
+        if (browserContext != null) {
+            browserContext.close();
+        }
+
+        if (browser != null) {
+            browser.close();
+        }
+
+        if (playwright != null) {
+            playwright.close();
+        }
+    }
+
+    // Happy-path сценарій: створюємо запис через UI, перевіряємо його появу і видаляємо назад через UI.
+    @Test
+    void energyReadingHappyPathCreatesAndDeletesEntry() {
+        runWithDiagnostics("energy-reading-happy-path-creates-and-deletes-entry", () -> {
+            // Генеруємо унікальні значення, щоб тест не конфліктував з уже наявними даними.
+            String uniqueSuffix = String.valueOf(Instant.now().toEpochMilli());
+            String uniqueConsumer = "E2E Consumer " + uniqueSuffix;
+            createdConsumer = uniqueConsumer;
+
+            // Переходимо на сторінку додавання і чекаємо, поки форма стане видимою.
+            page.navigate(baseUrl + "/add");
+            waitForAddPageForm();
+            assertThat(page.locator("form").count()).isEqualTo(1);
+
+            // Заповнюємо форму тестовими даними.
+            setInputValue("consumer", uniqueConsumer);
+            setInputValue("supplier", "E2E Supplier");
+            setInputValue("technician", "E2E Technician");
+            setInputValue("reading_date", "2026-05-04");
+            setInputValue("reading_value", "12345.6");
+            setInputValue("address", "Test Street 1");
+            setInputValue("tariff_zone", "T1");
+            setInputValue("price_per_kwh", "4.32");
+            setInputValue("experience_years", "5");
+            setInputValue("meter_type", "Digital");
+
+            // Відправляємо форму і чекаємо повернення на головну сторінку зі списком показників.
+            page.locator("button[type='submit']").click();
+            page.waitForURL(baseUrl + "/");
+            waitForEnergyPageHeader();
+
+            // Перевіряємо, що щойно створений рядок дійсно з'явився в таблиці.
+            Locator createdRow = waitForRowContaining(uniqueConsumer,
+                "Created energy reading row did not appear on the main page.");
+            assertThat(createdRow.textContent())
+                .contains(uniqueConsumer)
+                .contains("E2E Supplier");
+
+            // Видаляємо створений запис у межах самого happy-path сценарію.
+            deleteEnergyRow(uniqueConsumer);
+            createdConsumer = null;
+        });
+    }
+
+    // Видаляє рядок із таблиці за унікальним іменем споживача і перевіряє, що він зник із UI.
+    private void deleteEnergyRow(String uniqueConsumer) {
+        page.navigate(baseUrl + "/");
+        waitForEnergyPageHeader();
+
+        // Якщо рядок уже зник, додаткових дій не потрібно.
+        Locator rowToDelete = findRowContaining(uniqueConsumer);
+        if (rowToDelete == null) {
+            return;
+        }
+
+        // Натискаємо кнопку видалення і чекаємо, поки рядок зникне з таблиці.
+        rowToDelete.locator("button[type='submit']").click();
+        page.waitForURL(baseUrl + "/");
+        waitForEnergyPageHeader();
+        waitFor(() -> findRowContaining(uniqueConsumer) == null,
+            "Deleted energy reading row is still visible on the main page.");
+
+        assertThat(page.locator("body").textContent()).doesNotContain(uniqueConsumer);
+    }
+
+    // Чекає появи рядка з потрібним текстом і повертає знайдений locator.
+    private Locator waitForRowContaining(String text, String failureMessage) {
+        waitFor(() -> findRowContaining(text) != null, failureMessage);
+        return findRowContaining(text);
+    }
+
+    // Шукає перший рядок таблиці, у тексті якого міститься потрібне значення.
+    private Locator findRowContaining(String text) {
+        Locator rows = page.locator("tbody tr");
+        int count = rows.count();
+        for (int index = 0; index < count; index++) {
+            Locator row = rows.nth(index);
+            String rowText = row.textContent();
+            if (rowText != null && rowText.contains(text)) {
+                return row;
+            }
+        }
+        return null;
+    }
+
+    // Заповнює input-поле за його HTML name-атрибутом.
+    private void setInputValue(String fieldName, String value) {
+        page.locator("[name='" + fieldName + "']").fill(value);
+    }
+
+    // Чекає, поки на головній сторінці з'явиться заголовок із показниками.
+    private void waitForEnergyPageHeader() {
+        page.locator("h1")
+            .filter(new Locator.FilterOptions().setHasText(ENERGY_PAGE_TITLE))
+            .first()
+            .waitFor(new Locator.WaitForOptions()
+                .setState(WaitForSelectorState.VISIBLE)
+                .setTimeout((double) pageReadyTimeoutMillis));
+    }
+
+    // Чекає, поки сторінка додавання повністю відрендерить форму.
+    private void waitForAddPageForm() {
+        page.locator("form")
+            .first()
+            .waitFor(new Locator.WaitForOptions()
+                .setState(WaitForSelectorState.VISIBLE)
+                .setTimeout((double) pageReadyTimeoutMillis));
+    }
+
+    // Простий polling helper для умов, які не мають зручного вбудованого wait у Playwright.
+    private void waitFor(BooleanSupplier condition, String failureMessage) {
+        long deadline = System.currentTimeMillis() + WAIT_TIMEOUT_MILLIS;
+        while (System.currentTimeMillis() < deadline) {
+            if (condition.getAsBoolean()) {
+                return;
+            }
+            page.waitForTimeout(POLL_INTERVAL_MILLIS);
+        }
+        throw new AssertionError(failureMessage);
+    }
+
+    // Зчитує та нормалізує базовий URL застосунку з property або environment variable.
+    private String resolveBaseUrl() {
+        String configuredUrl = resolveOptionalValue(BASE_URL_PROPERTY, BASE_URL_ENV);
+        if (configuredUrl == null || configuredUrl.isBlank()) {
+            return null;
+        }
+
+        return normalizeBaseUrl(configuredUrl);
+    }
+
+    // Прибирає зайвий "/" наприкінці та перевіряє, що URL абсолютний і коректний.
+    private String normalizeBaseUrl(String configuredUrl) {
+        String normalizedUrl = configuredUrl.endsWith("/")
+            ? configuredUrl.substring(0, configuredUrl.length() - 1)
+            : configuredUrl;
+
+        URI uri = URI.create(normalizedUrl);
+        if (uri.getScheme() == null || uri.getHost() == null) {
+            throw new IllegalStateException(
+                "E2E base URL must be an absolute URL, for example https://example.onrender.com"
+            );
+        }
+
+        return normalizedUrl;
+    }
+
+    // Читає значення спочатку з JVM property, а якщо його нема — із змінної середовища.
+    private String resolveOptionalValue(String propertyName, String envName) {
+        String configuredValue = System.getProperty(propertyName);
+        if (configuredValue == null || configuredValue.isBlank()) {
+            configuredValue = System.getenv(envName);
+        }
+        return configuredValue;
+    }
+
+    // Вибирає спосіб запуску браузера: через Selenium CDP у CI або локальний headless Chromium.
+    private Browser createBrowser() {
+        if (seleniumCdpUrl != null && !seleniumCdpUrl.isBlank()) {
+            // У CI підключаємось до вже запущеного Chromium у Selenium через CDP.
+            return playwright.chromium().connectOverCDP(seleniumCdpUrl);
+        }
+
+        return playwright.chromium().launch(new BrowserType.LaunchOptions()
+            .setHeadless(true)
+            .setArgs(List.of("--disable-dev-shm-usage", "--no-sandbox")));
+    }
+
+    // Визначає директорію для відео та screenshot, з урахуванням override через конфігурацію.
+    private Path resolveArtifactsDir() {
+        String configuredArtifactsDir = resolveOptionalValue(ARTIFACTS_DIR_PROPERTY, ARTIFACTS_DIR_ENV);
+        if (configuredArtifactsDir == null || configuredArtifactsDir.isBlank()) {
+            configuredArtifactsDir = "target/e2e-artifacts";
+        }
+        return Paths.get(configuredArtifactsDir).toAbsolutePath().normalize();
+    }
+
+    // Обирає timeout готовності сторінки: кастомний, Render-специфічний або дефолтний.
+    private int resolvePageReadyTimeoutMillis() {
+        String configuredTimeout = resolveOptionalValue(
+            PAGE_READY_TIMEOUT_MILLIS_PROPERTY,
+            PAGE_READY_TIMEOUT_MILLIS_ENV
+        );
+
+        if (configuredTimeout == null || configuredTimeout.isBlank()) {
+            // Render може запускати програму помітно довше, ніж локальне середовище.
+            return isRenderBaseUrl() ? RENDER_TIMEOUT_MILLIS : DEFAULT_PAGE_READY_TIMEOUT_MILLIS;
+        }
+        return Integer.parseInt(configuredTimeout);
+    }
+
+    // Повертає базовий timeout Playwright для дій і навігації.
+    private double resolvePlaywrightTimeoutMillis() {
+        return isRenderBaseUrl() ? RENDER_TIMEOUT_MILLIS : DEFAULT_TIMEOUT_MILLIS;
+    }
+
+    // Перевіряє, чи тести зараз виконуються проти Render-host, де очікування довші.
+    private boolean isRenderBaseUrl() {
+        if (baseUrl == null || baseUrl.isBlank()) {
+            return false;
+        }
+
+        URI uri = URI.create(baseUrl);
+        String host = uri.getHost();
+        return host != null && host.endsWith(RENDER_HOST_SUFFIX);
+    }
+
+    // Створює директорію артефактів і перетворює I/O помилки на зрозумілу помилку конфігурації тесту.
+    private void createDirectory(Path directory) {
+        try {
+            Files.createDirectories(directory);
+        } catch (Exception exception) {
+            throw new IllegalStateException(
+                "Unable to create E2E artifacts directory " + directory, exception);
+        }
+    }
+
+    // Запускає тест так, щоб при будь-якому падінні спочатку зберегти screenshot сторінки.
+    private void runWithDiagnostics(String testName, Runnable testBody) {
+        try {
+            testBody.run();
+        } catch (Throwable throwable) {
+            // Screenshot робимо до cleanup, щоб зберегти реальний стан сторінки в момент падіння.
+            captureFailureScreenshot(testName);
+            rethrowUnchecked(throwable);
+        }
+    }
+
+    // Зберігає full-page screenshot з унікальним ім'ям файлу в директорію артефактів.
+    private void captureFailureScreenshot(String testName) {
+        if (page == null) {
+            return;
+        }
+
+        Path screenshotPath = screenshotsDir.resolve(buildArtifactFileName(testName, "png"));
+        page.screenshot(new Page.ScreenshotOptions()
+            .setPath(screenshotPath)
+            .setFullPage(true)
+            .setType(ScreenshotType.PNG));
+    }
+
+    // Формує ім'я файлу артефакту з назви тесту та timestamp.
+    private String buildArtifactFileName(String testName, String extension) {
+        return sanitizeFileName(testName) + "-" + Instant.now().toEpochMilli() + "." + extension;
+    }
+
+    // Прибирає з імені файлу символи, які небажані для файлової системи.
+    private String sanitizeFileName(String value) {
+        return value.replaceAll("[^a-zA-Z0-9-_]+", "-");
+    }
+
+    // Перекидає checked/unchecked помилки без втрати первинного типу RuntimeException або Error.
+    private void rethrowUnchecked(Throwable throwable) {
+        if (throwable instanceof RuntimeException) {
+            throw (RuntimeException) throwable;
+        }
+
+        if (throwable instanceof Error) {
+            throw (Error) throwable;
+        }
+
+        throw new IllegalStateException(throwable);
+    }
+}


### PR DESCRIPTION
### What does this PR do?

- adds a Playwright for Java happy-path E2E test suite in EnergyHappyPathE2ETests
- runs the E2E test against a real deployed application URL provided through e2e.base-url / E2E_BASE_URL
- records E2E videos and captures screenshots on failure into target/e2e-artifacts
- adds a dedicated Maven e2e-ui profile and Playwright dependency for *E2ETests.java
- adds a reusable run-e2e-test GitHub Actions workflow that runs the tests
- updates the Render deploy workflow to return the deployed application_url and wires CI to run E2E tests after successful PR deploys
- updates the README with the current local E2E command and the actual CI/E2E workflow flow

### Related issue
#7 
### Description for the changelog

``` 
Add Playwright-based happy-path E2E UI tests and CI wiring to run them against the deployed Render application.
```
